### PR TITLE
fix(docker): enable x11 forwarding for launching via ssh

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -7,18 +7,18 @@ COMMAND_IN_CONTAINER="${1:-/bin/bash}"
 # shellcheck disable=SC1091
 source /opt/autoware/env/autoware.env
 
-xhost +local:
-
 docker run -it --rm --net host --privileged \
     --gpus all \
     -e CYCLONEDDS_URI \
     -e DISPLAY="${DISPLAY}" \
+    -e NO_AT_BRIDGE=1 \
     -e RMW_IMPLEMENTATION \
     -e ROS_DOMAIN_ID \
+    -v "${HOME}"/.Xauthority:/root/.Xauthority:rw \
+    -v "${ROOT_DIR}":/workspace \
     -v /opt/autoware:/opt/autoware \
     -v /sys:/sys \
     -v /tmp/.X11-unix/:/tmp/.X11-unix: \
-    -v "${ROOT_DIR}":/workspace \
     -w /workspace \
     perception_ecu:latest \
     /bin/bash -c "${COMMAND_IN_CONTAINER}"


### PR DESCRIPTION
Signed-off-by: Akihito OHSATO <aohsato@gmail.com>

## Description

When developing on host machine via ssh, x11 running in a peception ecu (remote machine) needs to be forwarded to the host machine.
This modification adds startup options and environment variables for this purpose.

## Related links

## Tests performed

1. Log in to perception ecu from the host machine via ssh with the X forwarding option enabled. 
```sh
ssh <username>@<hostname> -X
```

2. Execute `Running docker` step in this [README](https://github.com/tier4/perception_ecu_container/blob/main/README.md).

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.