### PR TITLE
fix(docker/Dockerfile): update kitware apt key

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ ARG L4T_VERSION=$L4T_RELEASE.$L4T_REVISION_MAJOR.$L4T_REVISION_MINOR
 FROM dustynv/ros:galactic-ros-base-l4t-r$L4T_VERSION
 
 # Fix GPG key to support recent key update
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
     && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
     && sed -i 's|deb https://apt.kitware.com/ubuntu/ bionic main|#&|g' /etc/apt/sources.list

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,11 @@ ARG L4T_VERSION=$L4T_RELEASE.$L4T_REVISION_MAJOR.$L4T_REVISION_MINOR
 
 FROM dustynv/ros:galactic-ros-base-l4t-r$L4T_VERSION
 
+# Fix GPG key to support recent key update
+RUN wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && sed -i 's|deb https://apt.kitware.com/ubuntu/ bionic main|#&|g' /etc/apt/sources.list
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     g++-8 \


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
**[HOTFIX]** Because of the recent apt-key update for kitware, `apt` related operation fails if the update is not reflected.
This treatment is the same way performed by [here](https://github.com/tier4/jetson_iv_container/pull/29) (TIER IV internal link).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/